### PR TITLE
Add dash for Pranathi's entry

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -17,7 +17,7 @@ author_info:
     email: olga.botvinnik@czbiohub.org
     affiliations:
       - Data Sciences Platform, Chan Zuckerberg Biohub
-
+  -
     github: pranathivemuri
     name: Venkata Naga Pranathi Vemuri
     initials: VNPV


### PR DESCRIPTION
Somehow @pranathivemuri's entry became the only author! So adding this dash should fix it.


<img width="614" alt="Screen Shot 2019-11-05 at 11 33 56 AM" src="https://user-images.githubusercontent.com/806256/68239661-3933a380-ffc0-11e9-8814-08f6c6f51a34.png">
