### PR TITLE
Fix references figures and tables

### DIFF
--- a/content/04.results.md
+++ b/content/04.results.md
@@ -1,9 +1,9 @@
 ## Results
 
-To determine whether short segments of sequences could detect gene orthologues, we $k$-merized orthologous genes derived from the ENSEMBL version 97 [@doi:10.1093/nar/gkx1098] COMPARA database [@doi:10.1093/database/bav096] (Fig.~\ref{fig:fig1}).
+To determine whether short segments of sequences could detect gene orthologues, we $k$-merized orthologous genes derived from the ENSEMBL version 97 [@doi:10.1093/nar/gkx1098] COMPARA database [@doi:10.1093/database/bav096] (Figure [@fig:fig1]).
 We compared human protein sequences to orthologous chimpanzee, mouse, (orangutan, bonobo, gorilla, macaque, opossum, platypus, chicken) protein sequences, as these are species used in [@doi:10.1038/nature10532].
 As a background, we randomly chose 10 non-orthologous genes relative to the human gene.
-In addition to $k$-merizing the protein-coding sequence, we also re-encoded the protein-coding sequence into Dayhoff [@raw:dayhoff1969atlas] and hydrophobic-polar encodings [@raw:phillips2012physical], show in Table~\ref{tab:encodings}.
+In addition to $k$-merizing the protein-coding sequence, we also re-encoded the protein-coding sequence into Dayhoff [@raw:dayhoff1969atlas] and hydrophobic-polar encodings [@raw:phillips2012physical], show in Table [@tbl:sequence-encodings].
 
 
 |  Amino acid                    | Property              | Dayhoff | Hydrophobic-polar (HP) |
@@ -19,7 +19,7 @@ In addition to $k$-merizing the protein-coding sequence, we also re-encoded the 
 Table: Dayhoff and hydrophobic-polar encodings are a reduced amino acid
 alphabet allowing for permissive cross-species sequence comparisons. For
 example, the amino acid sequence `SASHAFIERCE` would be Dayhoff-encoded
-to `bbbdbfecdac`, and HP-encoded to `phpphhhpppp`. {#tbl:example-id}
+to `bbbdbfecdac`, and HP-encoded to `phpphhhpppp`. {#tbl:sequence-encodings}
 
 
 
@@ -110,9 +110,9 @@ Cell type evolution
 
 Metazoan body plan formation
 
-- Early development in Cnidarians/Hydra [@doi:10.1126/science.aav9314; @ 10.1016/j.cell.2018.05.019]
+- Early development in Cnidarians/Hydra [@doi:10.1126/science.aav9314; @doi:10.1016/j.cell.2018.05.019]
 - sponges and others [@doi:10.1016/j.cell.2018.05.019]
-- planaria [@doi:10.1126/science.aaq1736; doi:10.1126/science.aaq1723],
+- planaria [@doi:10.1126/science.aaq1736; @doi:10.1126/science.aaq1723],
 - drosophila [@doi:10.1126/science.aan3235]
 - zebrafish [@doi:10.1126/science.aar3131; @doi:10.1126/science.aar5780; @doi:10.1126/science.aar4362],
 - mouse [@doi:10.1038/s41586-019-0969-x]


### PR DESCRIPTION
Thee old references were latex-style, now these are the [Manubot-style](https://github.com/manubot/rootstock/blob/master/USAGE.md)